### PR TITLE
Add `set-json-class` method

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,6 +11,7 @@
      "parser"
   ],
   "test-depends": [
+     "Cro::HTTP::Test"
   ],
   "meta-version": "0",
   "build-depends": [

--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ $service.start;
 react  { whenever signal(SIGINT) { $service.stop; exit; } }
 ```
 
+```raku
+use Cro::HTTP::Client;
+use JSON::Class;
+use Cro::HTTP::BodyParser::JSONClass;
+
+my $client1 = Cro::HTTP::Client.new: body-parsers => [Cro::HTTP::BodyParser::JSONClass[HelloClass]];
+my $obj1 = await $client1.get-body: 'https://jsonclass.free.beeceptor.com/hello';
+say $obj1.raku;
+=output HelloClass.new(firstname => "fname", lastname => "lname")␤
+
+# Setting the JSON class after creating an instance of Cro::HTTP::Client
+my $body-parser = Cro::HTTP::BodyParser::JSONClass.new;
+my $client2 = Cro::HTTP::Client.new: body-parsers => [$body-parser];
+$body-parser.set-json-class: HelloClass;
+my $obj2 = await $client2.get-body: 'https://jsonclass.free.beeceptor.com/hello';
+say $obj2.raku;
+=output HelloClass.new(firstname => "fname", lastname => "lname")␤
+```
+
 ## Description
 
 This provides a specialised [Cro::BodyParser](https://cro.services/docs/reference/cro-http-router#Adding_custom_request_body_parsers) that will parse a JSON ('application/json') request body to the specified
@@ -79,6 +98,8 @@ class SomeBodyParser does Cro::HTTP::BodyParser::JSONClass[HelloClass] {
 ```
 
 And then use `SomeBodyParser` in place of `Cro::HTTP::BodyParser::JSONClass`.
+
+The BodyParser has a `set-json-class` method which can be used to set the `JSON::Class` class to another class whenever needed.
 
 ## Installation
 

--- a/examples/client
+++ b/examples/client
@@ -1,0 +1,27 @@
+#!/usr/bin/env raku
+
+use Cro::HTTP::Client;
+use JSON::Class;
+use Cro::HTTP::BodyParser::JSONClass;
+
+class HelloClass does JSON::Class {
+    has Str $.firstname;
+    has Str $.lastname;
+
+    method hello(--> Str) {
+        "Hello, $.firstname() $.lastname()";
+    }
+}
+
+my $client1 = Cro::HTTP::Client.new: body-parsers => [Cro::HTTP::BodyParser::JSONClass[HelloClass]];
+my $obj1 = await $client1.get-body: 'https://jsonclass.free.beeceptor.com/hello';
+say $obj1.raku;
+=output HelloClass.new(firstname => "fname", lastname => "lname")␤
+
+# Setting the JSON class after creating an instance of Cro::HTTP::Client
+my $body-parser = Cro::HTTP::BodyParser::JSONClass.new;
+my $client2 = Cro::HTTP::Client.new: body-parsers => [$body-parser];
+$body-parser.set-json-class: HelloClass;
+my $obj2 = await $client2.get-body: 'https://jsonclass.free.beeceptor.com/hello';
+say $obj2.raku;
+=output HelloClass.new(firstname => "fname", lastname => "lname")␤


### PR DESCRIPTION
- Add `set-json-class` method
- Make role parameter optional
- Use Cro::HTTP::Test

I wanted to open an issue, but I created a PR instead. I may also have gone a little bit overboard.

I was using `Cro::HTTP::BodyParser::JSONClass` with `Cro::HTTP::Client` and I realized I have to pass the body parser to the class and can't set it when using the `get` method.

Maybe there is another way or a better way that I'm unaware of, but I made the role parameter optional and added a `set-json-class` method which can change the `JSON::Class` class after instanciating `Cro::HTTP::Client` (before using `.get` for example).